### PR TITLE
Comment sample inventory file

### DIFF
--- a/inventory.csv
+++ b/inventory.csv
@@ -1,2 +1,7 @@
+#
+# NOTES: 
+#   - the first row MUST be the header for the csv file. Do not add a # in front of it, that will cause it to be ignored
+#   - username and password are optional. you can specify them in the TOML configuration file if it is the same for all devices of a specific OS type
+#
 ipaddr,host,os_name,username,password
-# ...
+# 1.1.1.1,test,ios,cisco,cisco


### PR DESCRIPTION
Added comments to the sample inventory file so that the user knows that:
- the header line cannot have a # in it
- username and password can be define at the os level in the configuration file and omitted from the inventory