### PR TITLE
Adding ability to --limit by ipnetwork

### DIFF
--- a/docs/usage-filtering.md
+++ b/docs/usage-filtering.md
@@ -29,12 +29,29 @@ $ netcfgbu backup --limit 'os_name=iosxe|nxos'
 Example: Select all hosts that do _not_ "iosxe" or "nxos" as the network os_name:
 ```shell script
 $ netcfgbu backup --exclude 'os_name=iosxe|nxos'
-
+```
 
 Example: Select all hosts that use "iosxe" or "nxos" **and** have a name suffix of "mycorp.com"
 ```shell script
 $ netcfgbu backup --limit 'os_name=iosxe|nxos' --limit 'host=.*mycorp.com'
 ```
+
+Example: Select a host with a specific IP addresses:
+```shell script
+$ netcfgbu backup --limit "ipaddr=10.0.20.10"
+```
+
+Example: Select all hosts with IP addresses in a given prefix:
+```shell script
+$ netcfgbu backup --limit "ipaddr=2620:10:abcd::/64"
+```
+
+Example: Select all hosts with IP addresses that match a regex:
+```shell script
+$ netcfgbu backup --limit "ipaddr=10.(10|30).5.\d+"
+```
+
+
 
 
 ## Filter by CSV File Contents

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -5,7 +5,7 @@ import csv
 
 def test_filtering_pass_include():
     """
-    Test the use-case where the constraint is a vliad set of "limits"
+    Test the use-case where the constraint is a valid set of "limits"
     """
     key_values = [("os_name", "eos"), ("host", ".*nyc1")]
     constraints = [f"{key}={val}" for key, val in key_values]
@@ -20,7 +20,7 @@ def test_filtering_pass_include():
     assert filter_fn(dict(os_name="eos", host="switch1.dc1")) is False
 
 
-def test_filtering_pass_exlcude():
+def test_filtering_pass_exclude():
     """
     Test use-case where the constraint is a valid set of "excludes"
     """
@@ -194,3 +194,140 @@ def test_filtering_fail_csv_notcsvfile():
 
     errmsg = excinfo.value.args[0]
     assert "not a CSV file." in errmsg
+
+
+def test_filtering_ipaddr_v4_include():
+    """
+    Test the ipaddr (Ipv4) include network address/prefix use-case
+    """
+    filter_fn = create_filter(
+        constraints=["ipaddr=10.10.0.2"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.0.2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.0.3", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.0.4", host="switch1.dc1")) is False
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=10.10.0.2/31"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.0.2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.0.3", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.0.4", host="switch1.dc1")) is False
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=10.10.0.0/16"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.0.2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.0.3", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.0.4", host="switch1.dc1")) is True
+
+
+def test_filtering_ipaddr_v4_exclude():
+    """
+    Test the ipaddr (Ipv4) exclude network address/prefix use-case
+    """
+    filter_fn = create_filter(
+        constraints=["ipaddr=10.10.0.2"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.0.2", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.0.3", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.0.4", host="switch1.dc1")) is True
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=10.10.0.2/31"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.0.2", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.0.3", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.0.4", host="switch1.dc1")) is True
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=10.10.0.0/16"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.0.2", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.0.3", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.0.4", host="switch1.dc1")) is False
+
+
+def test_filtering_ipaddr_v6_include():
+    """
+    Test the ipaddr (Ipv6) include network address/prefix use-case
+    """
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:10::2"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:10::3", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:10::4", host="switch1.dc1")) is False
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:10::2/127"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:10::3", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:10::4", host="switch1.dc1")) is False
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:10::0/64"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:10::3", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:10::4", host="switch1.dc1")) is True
+
+
+def test_filtering_ipaddr_v6_exclude():
+    """
+    Test the ipaddr (Ipv6) exclude network address/prefix use-case
+    """
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:10::2"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::2", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:10::3", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:10::4", host="switch1.dc1")) is True
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:10::2/127"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::2", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:10::3", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:10::4", host="switch1.dc1")) is True
+
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:10::0/64"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::2", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:10::3", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:10::4", host="switch1.dc1")) is False
+
+
+def test_filtering_ipaddr_regex_fallback():
+    """
+    Test the use-case of ipaddr filtering when a regex is used
+    """
+    filter_fn = create_filter(
+        constraints=["ipaddr=3001:10:(10|20)::2"], field_names=["ipaddr"], include=True
+    )
+
+    assert filter_fn(dict(ipaddr="3001:10:10::1", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="3001:10:20::2", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="3001:10:30::3", host="switch1.dc1")) is False
+
+    filter_fn = create_filter(
+        constraints=[r"ipaddr=10.10.10.\d{2}"], field_names=["ipaddr"], include=False
+    )
+
+    assert filter_fn(dict(ipaddr="10.10.10.1", host="switch1.nyc1")) is True
+    assert filter_fn(dict(ipaddr="10.10.10.10", host="switch1.nyc1")) is False
+    assert filter_fn(dict(ipaddr="10.10.10.12", host="switch1.nyc1")) is False


### PR DESCRIPTION
Addresses #13 

This diff reworks the inventory filtering to add a `Filter` base class that will  provide additional filter types beyond regex. 

## IPFilter
Using this new class, an `IPFilter` filter provides the ability to limit inventory using ip addresses **or** prefixes:

```sh
$ ./bin/netcfgbu inventory list -C ~/netcfgbu/netcfgbu.toml -i ~/netcfgbu/inventory.csv --limit ipaddr=172.16.20.0/24
# ------------------------------------------------------------------------------

SUMMARY: TOTAL=1

    os_name      count
    ---------  -------
    ios              1

host    os_name    ipaddr       username    password
------  ---------  -----------  ----------  ----------
sw1     ios        172.16.20.3  admin       cisco123
```

```sh
$ ./bin/netcfgbu inventory list -C ~/netcfgbu/netcfgbu.toml -i ~/netcfgbu/inventory.csv --limit ipaddr=172.16.20.3
# ------------------------------------------------------------------------------

SUMMARY: TOTAL=1

    os_name      count
    ---------  -------
    ios              1

host    os_name    ipaddr       username    password
------  ---------  -----------  ----------  ----------
sw1     ios        172.16.20.3  admin       cisco123
```

```sh
$ ./bin/netcfgbu inventory list -C ~/netcfgbu/netcfgbu.toml -i ~/netcfgbu/inventory.csv --limit ipaddr=3001:10::3
# ------------------------------------------------------------------------------

SUMMARY: TOTAL=1

    os_name      count
    ---------  -------
    ios              1

host    os_name    ipaddr      username    password
------  ---------  ----------  ----------  ----------
sw2     ios        3001:10::3  admin       cisco123
```

```sh
$ ./bin/netcfgbu inventory list -C ~/netcfgbu/netcfgbu.toml -i ~/netcfgbu/inventory.csv --limit ipaddr=3001:10::/64
# ------------------------------------------------------------------------------

SUMMARY: TOTAL=1

    os_name      count
    ---------  -------
    ios              1

host    os_name    ipaddr      username    password
------  ---------  ----------  ----------  ----------
sw2     ios        3001:10::3  admin       cisco123
```

## RegexFilter
Any fieldname that isn't "ipaddr" will remain a `RegexFilter` to preserve compatibility:
```sh
$ ./bin/netcfgbu inventory list -C ~/netcfgbu/netcfgbu.toml -i ~/netcfgbu/inventory.csv --limit host="sw\d"
# ------------------------------------------------------------------------------

SUMMARY: TOTAL=1

    os_name      count
    ---------  -------
    ios              1

host    os_name    ipaddr       username    password
------  ---------  -----------  ----------  ----------
sw1     ios        172.16.20.3  admin       cisco123
```



# TODO:
This is currently a draft PR as an RFC to make sure this path forward with different filter types is good
- Add unittests
- Add docs for using the new IPFilter in CLI
- Add docstrings to help others create new filter types